### PR TITLE
fix Coloured Lights light through block

### DIFF
--- a/src/main/java/com/lowdragmc/shimmer/client/light/LightManager.java
+++ b/src/main/java/com/lowdragmc/shimmer/client/light/LightManager.java
@@ -49,13 +49,13 @@ public enum LightManager {
     
     private static String ChunkInjection(String s) {
         s = s.replace("void main()", "#moj_import <shimmer.glsl>\n\nvoid main()");
-        return new StringBuffer(s).insert(s.lastIndexOf('}'), "vertexColor = color_light(pos, vertexColor);\n").toString();
+        return new StringBuffer(s).insert(s.lastIndexOf('}'), "vertexColor = color_light_uv(pos, vertexColor,UV2);\n").toString();
     }
 
     private static String PositionInjection(String s) {
         //TODO fix armor lighting. what the hell!!!!!
         s = s.replace("void main()", "#moj_import <shimmer.glsl>\n\nvoid main()");
-        return new StringBuffer(s).insert(s.lastIndexOf('}'), "vertexColor = color_light(Position, vertexColor);\n").toString();
+        return new StringBuffer(s).insert(s.lastIndexOf('}'), "vertexColor = color_light_uv(Position, vertexColor,UV2);\n").toString();
     }
 
     private static String EntityInjectionLightMapColor(String s) {

--- a/src/main/resources/assets/minecraft/shaders/include/shimmer.glsl
+++ b/src/main/resources/assets/minecraft/shaders/include/shimmer.glsl
@@ -33,3 +33,23 @@ vec4 color_light(vec3 pos, vec4 vertex_color) {
     return vec4(vertex_color.rgb + lcolor_2, 1.0);
     //    return vec4(max(vertex_color.rgb, lcolor_2), 1.0);
 }
+
+vec4 color_light_uv(vec3 pos, vec4 vertex_color,ivec2 uv) {
+    vec3 lightColor = vec3(0., 0., 0.);
+    vec3 fragPos = pos + camPos;
+    for (int i = 0; i < lightCount; i++) {
+        Light l = lights[i];
+        float radius = pow(l.radius, 2);
+        vec3 poss = vec3(0.,0.,0.);
+        float intensity = pow(max(0., 1. - distance(l.position, fragPos) / l.radius), 2);
+        lightColor += l.color.rgb * l.color.a * intensity;
+    }
+
+    vec2 normalized_light = clamp(uv / 256.0, vec2(0.5 / 16.0), vec2(15.5 / 16.0));
+    // from light.glsl#minecraft_sample_lightmap
+
+    vec3 lcolor_2 = clamp(lightColor.rgb, 0.0f, 1.0f);
+
+    return vec4(vertex_color.rgb + lcolor_2 * normalized_light.x, 1.0);
+    // just take x coordinate into account as it represent block light , skip the sky light
+}


### PR DESCRIPTION
# Before Fix  

<img width="1280" alt="before_fix" src="https://user-images.githubusercontent.com/26162862/170823002-2442099d-8d44-448f-8eea-c8a405ce9223.png">

# After Fix  

<img width="1280" alt="after_fix" src="https://user-images.githubusercontent.com/26162862/170823003-a92f2837-54e3-4bab-8e83-bc7c8eef012f.png">

#  some problem  

if the light source is at the corner of block , it still light through the block
its minecraft's self problem
<img width="1280" alt="minecraft's problem" src="https://user-images.githubusercontent.com/26162862/170823036-fcbf28b3-fdb7-43fc-ad61-ba099e43c0e0.png">

# how to fix  

similar to the origin function `color_light`  
add a function called `color_light_uv` , which need a extra argument called UV2
which represent the block light
the `vertex_color`  will become `vec4(vertex_color.rgb + lcolor_2 * normalized_light.x, 1.0)`
some vertex shader doesn't has a attribute in called UV2,so only some shader is applied this fix