### PR TITLE
allow get Light data from BlockEntity by add an extra parameter BlockPos for supplier

### DIFF
--- a/src/main/java/com/lowdragmc/shimmer/core/mixins/MultiLayerModelLoaderMixin.java
+++ b/src/main/java/com/lowdragmc/shimmer/core/mixins/MultiLayerModelLoaderMixin.java
@@ -21,12 +21,8 @@ public class MultiLayerModelLoaderMixin implements IMultiLayerModelLoader {
 
     public void update() {
         BLOCK_LAYERS = ImmutableBiMap.<String, RenderType>builder()
-                .put("solid", RenderType.solid())
-                .put("cutout", RenderType.cutout())
-                .put("cutout_mipped", RenderType.cutoutMipped())
+                .putAll(BLOCK_LAYERS)
                 .put("bloom", ShimmerRenderTypes.bloom())
-                .put("translucent", RenderType.translucent())
-                .put("tripwire", RenderType.tripwire())
                 .build();
     }
 }

--- a/src/main/java/com/lowdragmc/shimmer/core/mixins/RenderTypeMixin.java
+++ b/src/main/java/com/lowdragmc/shimmer/core/mixins/RenderTypeMixin.java
@@ -20,12 +20,9 @@ public class RenderTypeMixin {
 
     @Inject(method = "chunkBufferLayers",  at = @At(value = "HEAD"), cancellable = true)
     private static void injectChunkBufferLayers(CallbackInfoReturnable<List<RenderType>> cir) {
-        cir.setReturnValue(ImmutableList.of(
-                RenderType.solid(),
-                RenderType.cutoutMipped(),
-                RenderType.cutout(),
-                ShimmerRenderTypes.bloom(),
-                RenderType.translucent(),
-                RenderType.tripwire()));
+        cir.setReturnValue(ImmutableList.<RenderType>builder()
+                .addAll(cir.getReturnValue())
+                .add(ShimmerRenderTypes.bloom())
+                .build());
     }
 }


### PR DESCRIPTION
registerBlockLight's supplier add an extra BlockPos parameter
by this way,we can get data from BlockEntity via another fixed argument `Minecraft.getInstance().level`